### PR TITLE
Update submodule and README.md to point at correct drone_causality repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "drone_causality"]
 	path = drone_causality
-	url = git@github.com:dolphonie/drone_causality.git
+	url = git@github.com:makramchahine/drone_causality.git

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Rosetta Drone
-This repository contains all code run onboard the drone to complete online testinf for the paper "Robust Visual Flight Navigation with Liquid Neural Networks". For training/offline analysis code, see [this repository](https://github.com/dolphonie/drone_causality)
+This repository contains all code run onboard the drone to complete online testinf for the paper "Robust Visual Flight Navigation with Liquid Neural Networks". For training/offline analysis code, see [this repository](https://github.com/makramchahine/drone_causality)
 
 ## Installation Guide
 ### Hardware


### PR DESCRIPTION
This pull request updates the submodule URL and README.md link to point to the drone_causality repo hosted at https://github.com/makramchahine, since the original one doesn't seem to  be publicly available. 